### PR TITLE
Symfony 4.x quickfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 1.0.2
+### Added
+- Deprecated \Symfony\Component\DependencyInjection\DefinitionDecorator class removed and 
+  used \Symfony\Component\DependencyInjection\ChildDefinition
+
 ## 1.0.1
 ### Added
 - added support for Symfony 4.x

--- a/src/DependencyInjection/Security/Factory/BearerFactory.php
+++ b/src/DependencyInjection/Security/Factory/BearerFactory.php
@@ -2,9 +2,9 @@
 
 namespace Paysera\BearerAuthenticationBundle\DependencyInjection\Security\Factory;
 
+use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\DefinitionDecorator;
 use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\SecurityFactoryInterface;
 
@@ -21,14 +21,14 @@ class BearerFactory implements SecurityFactoryInterface
         $container
             ->setDefinition(
                 $providerId,
-                new DefinitionDecorator('paysera_bearer_authentication.security_authentication_provider.bearer_provider')
+                new ChildDefinition('paysera_bearer_authentication.security_authentication_provider.bearer_provider')
             )
             ->replaceArgument(0, new Reference($userProvider));
 
         $listenerId = 'security.authentication.listener.bearer.'.$id;
         $listener = $container->setDefinition(
             $listenerId,
-            new DefinitionDecorator('paysera_bearer_authentication.listener.bearer_listener')
+            new ChildDefinition('paysera_bearer_authentication.listener.bearer_listener')
         );
 
         return [$providerId, $listenerId, $defaultEntryPoint];


### PR DESCRIPTION
For Symfony 4.x, Deprecated \Symfony\Component\DependencyInjection\DefinitionDecorator class removed and 
  used \Symfony\Component\DependencyInjection\ChildDefinition